### PR TITLE
Add Table of Contents to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,180 @@
-# pycourse
+# pycourse  
+  
+## Table Of Contents / Содержание:  
+  
+  
+  
+[Seminar01](Seminar01.ipynb):   
+
+1. <details>
+    <summary> Общие сведения о Python. Стиль кодирования. Тестирование кода.</summary>
+      * 1.1. Общие сведения о Python  
+          * 1.1.1. Настройка рабочего окружения  
+          * 1.1.2. Jupyter Notebook  
+          * 1.1.3. Примеры кода на Python  
+          * 1.1.4. Запуск вне jupyter notebook  
+      * 1.2. Стиль кодирования  
+          * 1.2.1. Внешний вид кода  
+          * 1.2.2. Кавычки и пробелы  
+          * 1.2.3. Соглашения об именовании  
+          * 1.2.4. Рекомендации по написанию кода  
+      * 1.3. Тестирование  
+          * 1.3.1. Модуль unittest  
+          * 1.3.2. Модуль doctest  
+    
+</details>  
+  
+  
+  
+  
+[Seminar02](Seminar02.ipynb):   
+2. <details>
+<summary> Базовые типы данных. Определение переменных. Строки, списки, кортежи, словари, наборы.  </summary>
+    * 2.1. Базовые типы  
+        * 2.1.1. bool  
+        * 2.1.2. integer  
+        * 2.1.3. float  
+        * 2.1.4. Строки  
+    * 2.2. Вспомогательные типы  
+        * 2.2.1. Комплексные числа  
+        * 2.2.2. Дроби  
+    * 2.3. Контейнеры  
+        * 2.3.1. Списки  
+        * 2.3.2. Кортежи  
+        * 2.3.3. Словари  
+        * 2.3.4. Множества  
+    * 2.4. Функции  
+    * 2.5. Классы  
+    * 2.6. None  
+  
+  
+</details>
+  
+  
+  
+[Seminar03](Seminar03.ipynb):   
+3. <details>
+<summary> Ветвления, циклы, функции, классы, ввод и вывод, исключения, менеджеры контекста, модули и пакеты  </summary>
+    * 3.1. Ветвления и циклы  
+        * 3.1.1. Веткления  
+        * 3.1.2. Циклы for  
+        * 3.1.3. Циклы while  
+    * 3.2. Функции  
+        * 3.2.1. С фиксированным набором аргументов  
+        * 3.2.2. Значения аргументов по умолчанию  
+        * 3.2.3. Переменное число аргументов  
+        * 3.2.4. Декораторы  
+        * 3.2.5. Генераторы  
+        * 3.2.6. Лямбда-функции  
+    * 3.3. Классы  
+        * 3.3.1. Методы и поля  
+        * 3.3.2. Приватные методы  
+        * 3.3.3. Наследование  
+        * 3.3.4. Магические методы  
+    * 3.4. Ввод и вывод  
+        * 3.4.1. В консоль и из консоли  
+        * 3.4.2. В файл и из файла  
+    * 3.5. Исключения  
+    * 3.6. Менеджеры контекста  
+    * 3.7. Модули и пакеты модулей  
+  
+  
+</details>
+  
+[Seminar04](Seminar04.ipynb):   
+4. <details>
+<summary> Python Standard Library modules  </summary>
+    * 4.1 math  
+    * 4.2 collections  
+        * 4.2.1 ChainMap  
+        * 4.2.2 Counter  
+        * 4.2.3 defaultdict  
+        * 4.2.4 namedtuple  
+        * 4.2.5 OrderedDict  
+    * 4.3 itertools  
+        * 4.3.1 Infinite  
+        * 4.3.2 Reducers  
+        * 4.3.3 Combinatoric  
+    * 4.4 copy  
+    * 4.5 glob  
+    * 4.6 os  
+    * 4.7 sys  
+    * 4.8 argparse  
+    * 4.9 json  
+  
+  
+</details>
+  
+[Seminar05](Seminar05.ipynb):   
+5. <details>
+<summary> numpy, scipy and pandas modules  </summary>
+    * 5.1. numpy  
+        * 5.1.1 N-dimensional arrays  
+            * 5.1.1.1 Basic Usage  
+            * 5.1.1.2 Operations with ndarrays  
+        * 5.1.2 Matrixes  
+        * 5.1.3. Matrix functions  
+        * 5.1.4. Random arrays  
+        * 5.1.5. Various stats  
+        * 5.1.6. Input and output  
+    * 5.2. scipy  
+        * 5.2.1. cluster  
+        * 5.2.2. interpolate  
+    * 5.3 pandas  
+  
+  
+</details>
+  
+[Seminar06](Seminar06.ipynb):   
+6. <details>
+<summary> SymPy и matplotlib  </summary>
+    * 6.1. SymPy  
+        * 6.1.1. Многочлены и рациональные функции  
+        * 6.1.2. Элементарные функции  
+        * 6.1.3. Решение уравнений  
+        * 6.1.4. Производные  
+        * 6.1.5. Интегралы  
+        * 6.1.6. Пределы  
+        * 6.1.7. Дифференциальные уравнения  
+        * 6.1.8. Линейная алгебра  
+        * 6.1.9. Графики  
+    * 6.2. matplotlib  
+    * 6.3. seaborn  
+  
+  
+</details>
+  
+  
+[Seminar07](Seminar07.ipynb):   
+7. <details>
+<summary> Параллельные вычисления. Модули threading, multiprocessing, subprocess.  </summary>
+    * Параллельные вычисления  
+    * 7.1. Модуль threading  
+        * 7.1.1. Класс threading.Thread  
+        * 7.1.2. Класс threading.Lock  
+        * 7.1.3. Класс threading.Barrier  
+    * 7.2. Модуль multiprocessing  
+        * 7.2.1. Класс multiprocessing.Process  
+        * 7.2.2. Класс multiprocessing.Pool  
+        * 7.2.3. Обмен данными между процессами  
+            * 7.2.3.1. На основе очереди  
+            * 7.2.3.2. На основе пайпов  
+    * 7.3. Модуль subprocess  
+    * 7.4. mpi4py  
+    * 7.5. Другие возможности  
+  
+  
+</details>
+  
+[Seminar08](Seminar08.ipynb):   
+8. <details>
+<summary> Совместное использование C++ и Python. Модуль CherryPy для создания веб-приложений.  </summary>
+    * 8.1. Совместное использование с C++  
+        * 8.1.1. swig  
+        * 8.1.2. cffi  
+        * 8.1.3. ctypes  
+    * 8.2. Python для создания веб-приложений  
+        * 8.2.1. Шаблонный движок jinja2  
+        * 8.2.2. Модуль CherryPy  
+        * 8.2.3. Модуль CherryPy с Ajax, пример из официальной документации  
+</details>

--- a/README.md
+++ b/README.md
@@ -4,177 +4,270 @@
   
   
   
-[Seminar01](Seminar01.ipynb):   
-
-1. <details>
-    <summary> Общие сведения о Python. Стиль кодирования. Тестирование кода.</summary>
-      * 1.1. Общие сведения о Python  
-          * 1.1.1. Настройка рабочего окружения  
-          * 1.1.2. Jupyter Notebook  
-          * 1.1.3. Примеры кода на Python  
-          * 1.1.4. Запуск вне jupyter notebook  
-      * 1.2. Стиль кодирования  
-          * 1.2.1. Внешний вид кода  
-          * 1.2.2. Кавычки и пробелы  
-          * 1.2.3. Соглашения об именовании  
-          * 1.2.4. Рекомендации по написанию кода  
-      * 1.3. Тестирование  
-          * 1.3.1. Модуль unittest  
-          * 1.3.2. Модуль doctest  
-    
-</details>  
-  
-  
-  
-  
-[Seminar02](Seminar02.ipynb):   
-2. <details>
-<summary> Базовые типы данных. Определение переменных. Строки, списки, кортежи, словари, наборы.  </summary>
-    * 2.1. Базовые типы  
-        * 2.1.1. bool  
-        * 2.1.2. integer  
-        * 2.1.3. float  
-        * 2.1.4. Строки  
-    * 2.2. Вспомогательные типы  
-        * 2.2.1. Комплексные числа  
-        * 2.2.2. Дроби  
-    * 2.3. Контейнеры  
-        * 2.3.1. Списки  
-        * 2.3.2. Кортежи  
-        * 2.3.3. Словари  
-        * 2.3.4. Множества  
-    * 2.4. Функции  
-    * 2.5. Классы  
-    * 2.6. None  
-  
-  
-</details>
-  
-  
-  
-[Seminar03](Seminar03.ipynb):   
-3. <details>
-<summary> Ветвления, циклы, функции, классы, ввод и вывод, исключения, менеджеры контекста, модули и пакеты  </summary>
-    * 3.1. Ветвления и циклы  
-        * 3.1.1. Веткления  
-        * 3.1.2. Циклы for  
-        * 3.1.3. Циклы while  
-    * 3.2. Функции  
-        * 3.2.1. С фиксированным набором аргументов  
-        * 3.2.2. Значения аргументов по умолчанию  
-        * 3.2.3. Переменное число аргументов  
-        * 3.2.4. Декораторы  
-        * 3.2.5. Генераторы  
-        * 3.2.6. Лямбда-функции  
-    * 3.3. Классы  
-        * 3.3.1. Методы и поля  
-        * 3.3.2. Приватные методы  
-        * 3.3.3. Наследование  
-        * 3.3.4. Магические методы  
-    * 3.4. Ввод и вывод  
-        * 3.4.1. В консоль и из консоли  
-        * 3.4.2. В файл и из файла  
-    * 3.5. Исключения  
-    * 3.6. Менеджеры контекста  
-    * 3.7. Модули и пакеты модулей  
-  
-  
-</details>
-  
-[Seminar04](Seminar04.ipynb):   
-4. <details>
-<summary> Python Standard Library modules  </summary>
-    * 4.1 math  
-    * 4.2 collections  
-        * 4.2.1 ChainMap  
-        * 4.2.2 Counter  
-        * 4.2.3 defaultdict  
-        * 4.2.4 namedtuple  
-        * 4.2.5 OrderedDict  
-    * 4.3 itertools  
-        * 4.3.1 Infinite  
-        * 4.3.2 Reducers  
-        * 4.3.3 Combinatoric  
-    * 4.4 copy  
-    * 4.5 glob  
-    * 4.6 os  
-    * 4.7 sys  
-    * 4.8 argparse  
-    * 4.9 json  
-  
-  
-</details>
-  
-[Seminar05](Seminar05.ipynb):   
-5. <details>
-<summary> numpy, scipy and pandas modules  </summary>
-    * 5.1. numpy  
-        * 5.1.1 N-dimensional arrays  
-            * 5.1.1.1 Basic Usage  
-            * 5.1.1.2 Operations with ndarrays  
-        * 5.1.2 Matrixes  
-        * 5.1.3. Matrix functions  
-        * 5.1.4. Random arrays  
-        * 5.1.5. Various stats  
-        * 5.1.6. Input and output  
-    * 5.2. scipy  
-        * 5.2.1. cluster  
-        * 5.2.2. interpolate  
-    * 5.3 pandas  
-  
-  
-</details>
-  
-[Seminar06](Seminar06.ipynb):   
-6. <details>
-<summary> SymPy и matplotlib  </summary>
-    * 6.1. SymPy  
-        * 6.1.1. Многочлены и рациональные функции  
-        * 6.1.2. Элементарные функции  
-        * 6.1.3. Решение уравнений  
-        * 6.1.4. Производные  
-        * 6.1.5. Интегралы  
-        * 6.1.6. Пределы  
-        * 6.1.7. Дифференциальные уравнения  
-        * 6.1.8. Линейная алгебра  
-        * 6.1.9. Графики  
-    * 6.2. matplotlib  
-    * 6.3. seaborn  
-  
-  
-</details>
-  
-  
-[Seminar07](Seminar07.ipynb):   
-7. <details>
-<summary> Параллельные вычисления. Модули threading, multiprocessing, subprocess.  </summary>
-    * Параллельные вычисления  
-    * 7.1. Модуль threading  
-        * 7.1.1. Класс threading.Thread  
-        * 7.1.2. Класс threading.Lock  
-        * 7.1.3. Класс threading.Barrier  
-    * 7.2. Модуль multiprocessing  
-        * 7.2.1. Класс multiprocessing.Process  
-        * 7.2.2. Класс multiprocessing.Pool  
-        * 7.2.3. Обмен данными между процессами  
-            * 7.2.3.1. На основе очереди  
-            * 7.2.3.2. На основе пайпов  
-    * 7.3. Модуль subprocess  
-    * 7.4. mpi4py  
-    * 7.5. Другие возможности  
-  
-  
-</details>
-  
-[Seminar08](Seminar08.ipynb):   
-8. <details>
-<summary> Совместное использование C++ и Python. Модуль CherryPy для создания веб-приложений.  </summary>
-    * 8.1. Совместное использование с C++  
-        * 8.1.1. swig  
-        * 8.1.2. cffi  
-        * 8.1.3. ctypes  
-    * 8.2. Python для создания веб-приложений  
-        * 8.2.1. Шаблонный движок jinja2  
-        * 8.2.2. Модуль CherryPy  
-        * 8.2.3. Модуль CherryPy с Ajax, пример из официальной документации  
-</details>
+<p><a href="Seminar01.ipynb">Seminar01</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> Общие сведения о Python. Стиль кодирования. Тестирование кода.</summary>
+            <ul>
+                <li>1.1. Общие сведения о Python
+                    <ul>
+                        <li>1.1.1. Настройка рабочего окружения </li>
+                        <li>1.1.2. Jupyter Notebook </li>
+                        <li>1.1.3. Примеры кода на Python </li>
+                        <li>1.1.4. Запуск вне jupyter notebook </li>
+                    </ul>
+                </li>
+                <li>1.2. Стиль кодирования
+                    <ul>
+                        <li>1.2.1. Внешний вид кода </li>
+                        <li>1.2.2. Кавычки и пробелы </li>
+                        <li>1.2.3. Соглашения об именовании </li>
+                        <li>1.2.4. Рекомендации по написанию кода </li>
+                    </ul>
+                </li>
+                <li>1.3. Тестирование
+                    <ul>
+                        <li>1.3.1. Модуль unittest </li>
+                        <li>1.3.2. Модуль doctest </li>
+                    </ul>
+                </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p> </p>
+<p><a href="Seminar02.ipynb">Seminar02</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> Базовые типы данных. Определение переменных. Строки, списки, кортежи, словари, наборы. </summary>
+            <ul>
+                <li>2.1. Базовые типы
+                    <ul>
+                        <li>2.1.1. bool </li>
+                        <li>2.1.2. integer </li>
+                        <li>2.1.3. float </li>
+                        <li>2.1.4. Строки </li>
+                    </ul>
+                </li>
+                <li>2.2. Вспомогательные типы
+                    <ul>
+                        <li>2.2.1. Комплексные числа </li>
+                        <li>2.2.2. Дроби </li>
+                    </ul>
+                </li>
+                <li>2.3. Контейнеры
+                    <ul>
+                        <li>2.3.1. Списки </li>
+                        <li>2.3.2. Кортежи </li>
+                        <li>2.3.3. Словари </li>
+                        <li>2.3.4. Множества </li>
+                    </ul>
+                </li>
+                <li>2.4. Функции </li>
+                <li>2.5. Классы </li>
+                <li>2.6. None </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p></p>
+<p><a href="Seminar03.ipynb">Seminar03</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> Ветвления, циклы, функции, классы, ввод и вывод, исключения, менеджеры контекста, модули и пакеты </summary>
+            <ul>
+                <li>3.1. Ветвления и циклы
+                    <ul>
+                        <li>3.1.1. Веткления </li>
+                        <li>3.1.2. Циклы for </li>
+                        <li>3.1.3. Циклы while </li>
+                    </ul>
+                </li>
+                <li>3.2. Функции
+                    <ul>
+                        <li>3.2.1. С фиксированным набором аргументов </li>
+                        <li>3.2.2. Значения аргументов по умолчанию </li>
+                        <li>3.2.3. Переменное число аргументов </li>
+                        <li>3.2.4. Декораторы </li>
+                        <li>3.2.5. Генераторы </li>
+                        <li>3.2.6. Лямбда-функции </li>
+                    </ul>
+                </li>
+                <li>3.3. Классы
+                    <ul>
+                        <li>3.3.1. Методы и поля </li>
+                        <li>3.3.2. Приватные методы </li>
+                        <li>3.3.3. Наследование </li>
+                        <li>3.3.4. Магические методы </li>
+                    </ul>
+                </li>
+                <li>3.4. Ввод и вывод
+                    <ul>
+                        <li>3.4.1. В консоль и из консоли </li>
+                        <li>3.4.2. В файл и из файла </li>
+                    </ul>
+                </li>
+                <li>3.5. Исключения </li>
+                <li>3.6. Менеджеры контекста </li>
+                <li>3.7. Модули и пакеты модулей </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p></p>
+<p><a href="Seminar04.ipynb">Seminar04</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> Python Standard Library modules </summary>
+            <ul>
+                <li>4.1 math </li>
+                <li>4.2 collections
+                    <ul>
+                        <li>4.2.1 ChainMap </li>
+                        <li>4.2.2 Counter </li>
+                        <li>4.2.3 defaultdict </li>
+                        <li>4.2.4 namedtuple </li>
+                        <li>4.2.5 OrderedDict </li>
+                    </ul>
+                </li>
+                <li>4.3 itertools
+                    <ul>
+                        <li>4.3.1 Infinite </li>
+                        <li>4.3.2 Reducers </li>
+                        <li>4.3.3 Combinatoric </li>
+                    </ul>
+                </li>
+                <li>4.4 copy </li>
+                <li>4.5 glob </li>
+                <li>4.6 os </li>
+                <li>4.7 sys </li>
+                <li>4.8 argparse </li>
+                <li>4.9 json </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p></p>
+<p><a href="Seminar05.ipynb">Seminar05</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> numpy, scipy and pandas modules </summary>
+            <ul>
+                <li>5.1. numpy
+                    <ul>
+                        <li>5.1.1 N-dimensional arrays
+                            <ul>
+                                <li>5.1.1.1 Basic Usage </li>
+                                <li>5.1.1.2 Operations with ndarrays </li>
+                            </ul>
+                        </li>
+                        <li>5.1.2 Matrixes </li>
+                        <li>5.1.3. Matrix functions </li>
+                        <li>5.1.4. Random arrays </li>
+                        <li>5.1.5. Various stats </li>
+                        <li>5.1.6. Input and output </li>
+                    </ul>
+                </li>
+                <li>5.2. scipy
+                    <ul>
+                        <li>5.2.1. cluster </li>
+                        <li>5.2.2. interpolate </li>
+                    </ul>
+                </li>
+                <li>5.3 pandas </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p></p>
+<p><a href="Seminar06.ipynb">Seminar06</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> SymPy и matplotlib </summary>
+            <ul>
+                <li>6.1. SymPy
+                    <ul>
+                        <li>6.1.1. Многочлены и рациональные функции </li>
+                        <li>6.1.2. Элементарные функции </li>
+                        <li>6.1.3. Решение уравнений </li>
+                        <li>6.1.4. Производные </li>
+                        <li>6.1.5. Интегралы </li>
+                        <li>6.1.6. Пределы </li>
+                        <li>6.1.7. Дифференциальные уравнения </li>
+                        <li>6.1.8. Линейная алгебра </li>
+                        <li>6.1.9. Графики </li>
+                    </ul>
+                </li>
+                <li>6.2. matplotlib </li>
+                <li>6.3. seaborn </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p></p>
+<p><a href="Seminar07.ipynb">Seminar07</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> Параллельные вычисления. Модули threading, multiprocessing, subprocess. </summary>
+            <ul>
+                <li>Параллельные вычисления </li>
+                <li>7.1. Модуль threading
+                    <ul>
+                        <li>7.1.1. Класс threading.Thread </li>
+                        <li>7.1.2. Класс threading.Lock </li>
+                        <li>7.1.3. Класс threading.Barrier </li>
+                    </ul>
+                </li>
+                <li>7.2. Модуль multiprocessing
+                    <ul>
+                        <li>7.2.1. Класс multiprocessing.Process </li>
+                        <li>7.2.2. Класс multiprocessing.Pool </li>
+                        <li>7.2.3. Обмен данными между процессами
+                            <ul>
+                                <li>7.2.3.1. На основе очереди </li>
+                                <li>7.2.3.2. На основе пайпов </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>7.3. Модуль subprocess </li>
+                <li>7.4. mpi4py </li>
+                <li>7.5. Другие возможности </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p></p>
+<p><a href="Seminar08.ipynb">Seminar08</a>: </p>
+<ol>
+    <li>
+        <details open="">
+            <summary> Совместное использование C++ и Python. Модуль CherryPy для создания веб-приложений. </summary>
+            <ul>
+                <li>8.1. Совместное использование с C++
+                    <ul>
+                        <li>8.1.1. swig </li>
+                        <li>8.1.2. cffi </li>
+                        <li>8.1.3. ctypes </li>
+                    </ul>
+                </li>
+                <li>8.2. Python для создания веб-приложений
+                    <ul>
+                        <li>8.2.1. Шаблонный движок jinja2 </li>
+                        <li>8.2.2. Модуль CherryPy </li>
+                        <li>8.2.3. Модуль CherryPy с Ajax, пример из официальной документации </li>
+                    </ul>
+                </li>
+            </ul>
+        </details>
+    </li>
+</ol>
+<p></p>
+</div>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar01.ipynb">Seminar01</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> Общие сведения о Python. Стиль кодирования. Тестирование кода.</summary>
             <ul>
                 <li>1.1. Общие сведения о Python
@@ -42,7 +42,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar02.ipynb">Seminar02</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> Базовые типы данных. Определение переменных. Строки, списки, кортежи, словари, наборы. </summary>
             <ul>
                 <li>2.1. Базовые типы
@@ -78,7 +78,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar03.ipynb">Seminar03</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> Ветвления, циклы, функции, классы, ввод и вывод, исключения, менеджеры контекста, модули и пакеты </summary>
             <ul>
                 <li>3.1. Ветвления и циклы
@@ -123,7 +123,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar04.ipynb">Seminar04</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> Python Standard Library modules </summary>
             <ul>
                 <li>4.1 math </li>
@@ -157,7 +157,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar05.ipynb">Seminar05</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> numpy, scipy and pandas modules </summary>
             <ul>
                 <li>5.1. numpy
@@ -190,7 +190,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar06.ipynb">Seminar06</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> SymPy и matplotlib </summary>
             <ul>
                 <li>6.1. SymPy
@@ -216,7 +216,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar07.ipynb">Seminar07</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> Параллельные вычисления. Модули threading, multiprocessing, subprocess. </summary>
             <ul>
                 <li>Параллельные вычисления </li>
@@ -250,7 +250,7 @@ _Marked to HTML5_ was used from
 <p><a href="Seminar08.ipynb">Seminar08</a>: </p>
 <ol>
     <li>
-        <details open="">
+        <details>
             <summary> Совместное использование C++ и Python. Модуль CherryPy для создания веб-приложений. </summary>
             <ul>
                 <li>8.1. Совместное использование с C++

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   
 ## Table Of Contents / Содержание:  
   
+_Marked to HTML5_ was used from  
+[online Markdown editor](http://georgeosddev.github.io/markdown-edit/#)
   
   
 <p><a href="Seminar01.ipynb">Seminar01</a>: </p>

--- a/toc.md
+++ b/toc.md
@@ -1,0 +1,187 @@
+## Table Of Contents / Содержание:  
+Marked to HTML5 was used from  
+[online Markdown editor](http://georgeosddev.github.io/markdown-edit/#)  
+  
+  
+[Seminar01](Seminar01.ipynb):   
+
+1. <details>
+    <summary> Общие сведения о Python. Стиль кодирования. Тестирование кода.</summary>
+      * 1.1. Общие сведения о Python  
+          * 1.1.1. Настройка рабочего окружения  
+          * 1.1.2. Jupyter Notebook  
+          * 1.1.3. Примеры кода на Python  
+          * 1.1.4. Запуск вне jupyter notebook  
+      * 1.2. Стиль кодирования  
+          * 1.2.1. Внешний вид кода  
+          * 1.2.2. Кавычки и пробелы  
+          * 1.2.3. Соглашения об именовании  
+          * 1.2.4. Рекомендации по написанию кода  
+      * 1.3. Тестирование  
+          * 1.3.1. Модуль unittest  
+          * 1.3.2. Модуль doctest  
+    
+</details>  
+  
+  
+  
+  
+[Seminar02](Seminar02.ipynb):   
+2. <details>
+<summary> Базовые типы данных. Определение переменных. Строки, списки, кортежи, словари, наборы.  </summary>
+    * 2.1. Базовые типы  
+        * 2.1.1. bool  
+        * 2.1.2. integer  
+        * 2.1.3. float  
+        * 2.1.4. Строки  
+    * 2.2. Вспомогательные типы  
+        * 2.2.1. Комплексные числа  
+        * 2.2.2. Дроби  
+    * 2.3. Контейнеры  
+        * 2.3.1. Списки  
+        * 2.3.2. Кортежи  
+        * 2.3.3. Словари  
+        * 2.3.4. Множества  
+    * 2.4. Функции  
+    * 2.5. Классы  
+    * 2.6. None  
+  
+  
+</details>
+  
+  
+  
+[Seminar03](Seminar03.ipynb):   
+3. <details>
+<summary> Ветвления, циклы, функции, классы, ввод и вывод, исключения, менеджеры контекста, модули и пакеты  </summary>
+    * 3.1. Ветвления и циклы  
+        * 3.1.1. Веткления  
+        * 3.1.2. Циклы for  
+        * 3.1.3. Циклы while  
+    * 3.2. Функции  
+        * 3.2.1. С фиксированным набором аргументов  
+        * 3.2.2. Значения аргументов по умолчанию  
+        * 3.2.3. Переменное число аргументов  
+        * 3.2.4. Декораторы  
+        * 3.2.5. Генераторы  
+        * 3.2.6. Лямбда-функции  
+    * 3.3. Классы  
+        * 3.3.1. Методы и поля  
+        * 3.3.2. Приватные методы  
+        * 3.3.3. Наследование  
+        * 3.3.4. Магические методы  
+    * 3.4. Ввод и вывод  
+        * 3.4.1. В консоль и из консоли  
+        * 3.4.2. В файл и из файла  
+    * 3.5. Исключения  
+    * 3.6. Менеджеры контекста  
+    * 3.7. Модули и пакеты модулей  
+  
+  
+</details>
+  
+[Seminar04](Seminar04.ipynb):   
+4. <details>
+<summary> Python Standard Library modules  </summary>
+    * 4.1 math  
+    * 4.2 collections  
+        * 4.2.1 ChainMap  
+        * 4.2.2 Counter  
+        * 4.2.3 defaultdict  
+        * 4.2.4 namedtuple  
+        * 4.2.5 OrderedDict  
+    * 4.3 itertools  
+        * 4.3.1 Infinite  
+        * 4.3.2 Reducers  
+        * 4.3.3 Combinatoric  
+    * 4.4 copy  
+    * 4.5 glob  
+    * 4.6 os  
+    * 4.7 sys  
+    * 4.8 argparse  
+    * 4.9 json  
+  
+  
+</details>
+  
+[Seminar05](Seminar05.ipynb):   
+5. <details>
+<summary> numpy, scipy and pandas modules  </summary>
+    * 5.1. numpy  
+        * 5.1.1 N-dimensional arrays  
+            * 5.1.1.1 Basic Usage  
+            * 5.1.1.2 Operations with ndarrays  
+        * 5.1.2 Matrixes  
+        * 5.1.3. Matrix functions  
+        * 5.1.4. Random arrays  
+        * 5.1.5. Various stats  
+        * 5.1.6. Input and output  
+    * 5.2. scipy  
+        * 5.2.1. cluster  
+        * 5.2.2. interpolate  
+    * 5.3 pandas  
+  
+  
+</details>
+  
+[Seminar06](Seminar06.ipynb):   
+6. <details>
+<summary> SymPy и matplotlib  </summary>
+    * 6.1. SymPy  
+        * 6.1.1. Многочлены и рациональные функции  
+        * 6.1.2. Элементарные функции  
+        * 6.1.3. Решение уравнений  
+        * 6.1.4. Производные  
+        * 6.1.5. Интегралы  
+        * 6.1.6. Пределы  
+        * 6.1.7. Дифференциальные уравнения  
+        * 6.1.8. Линейная алгебра  
+        * 6.1.9. Графики  
+    * 6.2. matplotlib  
+    * 6.3. seaborn  
+  
+  
+</details>
+  
+  
+[Seminar07](Seminar07.ipynb):   
+7. <details>
+<summary> Параллельные вычисления. Модули threading, multiprocessing, subprocess.  </summary>
+    * Параллельные вычисления  
+    * 7.1. Модуль threading  
+        * 7.1.1. Класс threading.Thread  
+        * 7.1.2. Класс threading.Lock  
+        * 7.1.3. Класс threading.Barrier  
+    * 7.2. Модуль multiprocessing  
+        * 7.2.1. Класс multiprocessing.Process  
+        * 7.2.2. Класс multiprocessing.Pool  
+        * 7.2.3. Обмен данными между процессами  
+            * 7.2.3.1. На основе очереди  
+            * 7.2.3.2. На основе пайпов  
+    * 7.3. Модуль subprocess  
+    * 7.4. mpi4py  
+    * 7.5. Другие возможности  
+  
+  
+</details>
+  
+
+
+[Seminar08](Seminar08.ipynb):   
+8. <details>
+<summary> Совместное использование C++ и Python. Модуль CherryPy для создания веб-приложений.  </summary>
+    * 8.1. Совместное использование с C++  
+        * 8.1.1. swig  
+        * 8.1.2. cffi  
+        * 8.1.3. ctypes  
+    * 8.2. Python для создания веб-приложений  
+        * 8.2.1. Шаблонный движок jinja2  
+        * 8.2.2. Модуль CherryPy  
+        * 8.2.3. Модуль CherryPy с Ajax, пример из официальной документации  
+
+    
+  
+  
+</details>
+
+


### PR DESCRIPTION
Содержание в README -- для удобства, чтоб не нужно было лазить в ноутбук, чтобы узнать, что в нем.
Не получилось сделать в Markdown гитхаба глубокий список, вложенный в тег details.
Поэтому перевел все в HTML.